### PR TITLE
Fix bug with deepcopy

### DIFF
--- a/django_better_choices/__init__.py
+++ b/django_better_choices/__init__.py
@@ -65,6 +65,9 @@ class _Value(str):
     def display(self) -> str:
         return str(self.__display)
 
+    def __deepcopy__(self, memodict):
+        return self.__clone__()
+
 
 class _Subset(tuple):
     """An immutable subset of values, which is translated to inner choices class."""

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 
 from collections.abc import Iterable
@@ -217,6 +218,10 @@ class TestCase(unittest.TestCase):
     def test_str_methods(self):
         for method in (fn for fn in dir(str) if not fn.startswith('__')):
             self.assertIn(method, Choices.Value.__dict__)
+
+    def test_deepcopy_value(self):
+        copied_value = copy.deepcopy(self.Const.VAL1)
+        self.assertEqual('val1', copied_value)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello there 👋 

So we have an issue with using `django-better-choices` in DRF serializers. The choices end up as empty strings in fields where the serializer is instantiated.

From a quick debugging session, I've tracked down to the fact that [REST framework deep-copies the fields](https://github.com/encode/django-rest-framework/blob/bb133522efaf6ce3ae8fdf1dec6cd79566cfd166/rest_framework/serializers.py#L365-L372). 

I've written a minimal test case by calling `copy.deepcopy` on a choice value and the result returns empty. It works fine if the value is casted to a string before being passed to deepcopy: `copy.deepcopy(str(CHOICE.VALUE))`